### PR TITLE
Gitignore and overlapping test example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ stamp-vc
 /compile
 /test/testpoisson-dirichlet-neumann
 /test/testpoisson-assembly
+# ignore build directories
+/build*/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 set(TESTS
-  reactiondiffusion.cc
-  stokesdarcy.cc
-  stokesdarcy2.cc
-  testcouplinggfs.cc
-  testinstationarypoisson.cc
-  testlocalfunctionspace.cc
-  testmatrixconstruction.cc
-  testmortarpoisson.cc
-  testmultidomaingridfunctionspace.cc
-  testoverlappinginstationarypoisson.cc
-  testpoisson.cc
-  testpowermortarpoisson.cc
+  reactiondiffusion
+  stokesdarcy
+  stokesdarcy2
+  testcouplinggfs
+  testinstationarypoisson
+  testlocalfunctionspace
+  testmatrixconstruction
+  testmortarpoisson
+  testmultidomaingridfunctionspace
+  testoverlappinginstationarypoisson
+  testpoisson
+  testpowermortarpoisson
 )
 
 set(MOSTLYCLEANFILES)
@@ -37,7 +37,7 @@ install(FILES checkgeometry.hh
 
 foreach(_test ${TESTS})
   add_test(${_test} ${_test})
-#   target_link_libraries(${_test} "dunecommon")
+  target_link_libraries(${_test} ${DUNE_LIBS})
 endforeach(_test ${TESTS})
 
 # We do not want want to build the tests during make all,

--- a/test/proportionalflowcoupling.hh
+++ b/test/proportionalflowcoupling.hh
@@ -130,7 +130,7 @@ public:
 
     typedef typename LFSU1::Traits::SizeType size_type;
     typedef typename IG::Element Element;
-    typedef typename Element::Geometry::Jacobian GeometryJacobian;
+    typedef typename Element::Geometry::JacobianInverseTransposed GeometryJacobian;
 
     const double h_F = (ig.geometry().corner(0) - ig.geometry().corner(1)).two_norm();
 

--- a/test/testoverlappinginstationarypoisson.cc
+++ b/test/testoverlappinginstationarypoisson.cc
@@ -1,6 +1,5 @@
 #include "config.h"
 
-#include <dune/grid/sgrid.hh>
 #include <dune/grid/yaspgrid.hh>
 #include <dune/pdelab/multidomain/multidomaingridfunctionspace.hh>
 #include <dune/pdelab/finiteelementmap/qkfem.hh>
@@ -486,7 +485,7 @@ int main(int argc, char** argv) {
         Dune::PDELab::constraints(bctype,gfs,cc);
       */
 
-      auto f_ = Dune::PDELab::MultiDomain::interpolateOnSubProblems(g,left_sp_dt0,g,right_sp_dt0);
+//       auto f_ = Dune::PDELab::MultiDomain::interpolateOnSubProblems(g,left_sp_dt0,g,right_sp_dt0);
 
       osm.apply(time,dt,uold,unew);                           // do one time step
 


### PR DESCRIPTION
- Git ignore build\* directories
- Make overlapping test compile again
